### PR TITLE
update raynomics to be in sync with ray-0.1.2

### DIFF
--- a/raynomics/sparse/mvp.py
+++ b/raynomics/sparse/mvp.py
@@ -3,9 +3,6 @@ import numpy as np
 import scipy
 import scipy.sparse
 
-ray.register_class(scipy.sparse.csr.csr_matrix)
-ray.register_class(scipy.sparse.csc.csc_matrix)
-
 # Code for sparse matrix vector products
 
 def partition_matrix_rows(A, num_partitions):

--- a/test/test.py
+++ b/test/test.py
@@ -19,7 +19,7 @@ class SparseMVPTest(unittest.TestCase):
   def testMVP(self):
     # reloading is only neccessary in the test because we call ray.init twice
     reload(raynomics.sparse.mvp)
-    ray.init(start_ray_local=True, num_workers=16)
+    ray.init(num_workers=8)
 
     # Test a matrix-vector-product
     m = 5001
@@ -49,7 +49,7 @@ class SparseIRLBTest(unittest.TestCase):
     # reloading is only neccessary in the test because we call ray.init twice
     reload(raynomics.sparse.irlb)
     reload(raynomics.sparse.mvp)
-    ray.init(start_ray_local=True, num_workers=16)
+    ray.init(num_workers=8)
  
     m = 10000
     n = 5000


### PR DESCRIPTION
Removing some deprecated Ray API from raynomics. Works on top of ray-0.1.2.